### PR TITLE
JWT 인증 구현  및 Throttle 사용

### DIFF
--- a/iiol/accounts/urls.py
+++ b/iiol/accounts/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 from . import views
-from mybookwishlist import views as mybookwishlist_view
 
 app_name = 'accounts'
 

--- a/iiol/accounts/urls.py
+++ b/iiol/accounts/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from . import views
+from rest_framework.authtoken.views import obtain_auth_token
 
 app_name = 'accounts'
 
@@ -12,4 +13,8 @@ urlpatterns = [
     path('follower/', views.profile_edit, name='profile_edit'),
     path('password_change/', views.password_change,
          name='password_change')
+]
+
+urlpatterns += [
+    path(r'api-token-auth/', obtain_auth_token),
 ]

--- a/iiol/accounts/urls.py
+++ b/iiol/accounts/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from . import views
-from rest_framework.authtoken.views import obtain_auth_token
+
 
 app_name = 'accounts'
 
@@ -15,6 +15,14 @@ urlpatterns = [
          name='password_change')
 ]
 
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
+
 urlpatterns += [
-    path(r'api-token-auth/', obtain_auth_token),
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
 ]

--- a/iiol/barcode/views.py
+++ b/iiol/barcode/views.py
@@ -16,6 +16,7 @@ import json
 import os
 from datetime import datetime, timedelta
 from utils.library_api import LibraryApi
+from rest_framework.permissions import AllowAny
 from rest_framework.throttling import AnonRateThrottle
 from .tasks import save_book_on_DB
 
@@ -23,6 +24,7 @@ CACHE_TTL = getattr(settings, 'CACHE_TTL')
 
 
 class BarcodeView(APIView):
+    permission_classes = [AllowAny]
     queryset = Barcode.objects.all()
     serializer_class = BarcodeSerializer
     # parser_classes = (MultiPartParser, FormParser)

--- a/iiol/barcode/views.py
+++ b/iiol/barcode/views.py
@@ -1,15 +1,12 @@
 from rest_framework.views import APIView
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import JsonResponse
 from django.shortcuts import render
 from .models import Barcode
 from library.models import Library, SmallRegion, BigRegion
 from books.models import Book
-from .serializers import BarcodeSerializer
 from django.conf import settings
 from django.core.cache import cache
 from django.views.decorators.cache import cache_page
-from django.utils import timezone
-from django.forms.models import model_to_dict
 from books.serializers import BookSerializer
 from library.serializers import LibrarySerializer
 from .serializers import BarcodeSerializer
@@ -17,11 +14,9 @@ import cv2
 import numpy as np
 import json
 import os
-import io
-from PIL import Image
 from datetime import datetime, timedelta
 from utils.library_api import LibraryApi
-
+from rest_framework.throttling import AnonRateThrottle
 from .tasks import save_book_on_DB
 
 CACHE_TTL = getattr(settings, 'CACHE_TTL')

--- a/iiol/iiol/settings/common.py
+++ b/iiol/iiol/settings/common.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from pathlib import Path
 import os
 from os.path import abspath, dirname

--- a/iiol/iiol/settings/common.py
+++ b/iiol/iiol/settings/common.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     'rest_framework',    # Third Apps
-    'rest_framework.authtoken',
+    'rest_framework_simplejwt',
     'django_bootstrap5',
     'debug_toolbar',
     'drf_yasg',
@@ -141,9 +141,12 @@ REST_FRAMEWORK = {
     # 'DEFAULT_PERMISSION_CLASSES' : [
     #     'rest_framework.permissions.IsAuthenticated',
     # ],
+    'DEFAULT_PERMISSION_CLASSES' : [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication'
     ],
     'DEFAULT_THROTTLE_CLASSES' : [
         'rest_framework.throttling.AnonRateThrottle',
@@ -152,6 +155,13 @@ REST_FRAMEWORK = {
         'anon' : '100/hour',
         'user' : '3/sec',
     }
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=20),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=5),
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True,
 }
 
 INTERNAL_IPS = ['127.0.0.1']

--- a/iiol/iiol/settings/common.py
+++ b/iiol/iiol/settings/common.py
@@ -138,9 +138,6 @@ AUTH_USER_MODEL = "accounts.User"
 REST_FRAMEWORK = {
 	'PAGE_SIZE' : 10,
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    # 'DEFAULT_PERMISSION_CLASSES' : [
-    #     'rest_framework.permissions.IsAuthenticated',
-    # ],
     'DEFAULT_PERMISSION_CLASSES' : [
         'rest_framework.permissions.IsAuthenticated',
     ],

--- a/iiol/iiol/settings/common.py
+++ b/iiol/iiol/settings/common.py
@@ -42,8 +42,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
-    'rest_framework',
-    # Third Apps
+    'rest_framework',    # Third Apps
+    'rest_framework.authtoken',
     'django_bootstrap5',
     'debug_toolbar',
     'drf_yasg',
@@ -141,6 +141,10 @@ REST_FRAMEWORK = {
     # 'DEFAULT_PERMISSION_CLASSES' : [
     #     'rest_framework.permissions.IsAuthenticated',
     # ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ],
     'DEFAULT_THROTTLE_CLASSES' : [
         'rest_framework.throttling.AnonRateThrottle',
     ],

--- a/iiol/iiol/settings/common.py
+++ b/iiol/iiol/settings/common.py
@@ -135,6 +135,21 @@ DATABASES = {
 
 AUTH_USER_MODEL = "accounts.User"
 
+REST_FRAMEWORK = {
+	'PAGE_SIZE' : 10,
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    # 'DEFAULT_PERMISSION_CLASSES' : [
+    #     'rest_framework.permissions.IsAuthenticated',
+    # ],
+    'DEFAULT_THROTTLE_CLASSES' : [
+        'rest_framework.throttling.AnonRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES' : {
+        'anon' : '100/hour',
+        'user' : '3/sec',
+    }
+}
+
 INTERNAL_IPS = ['127.0.0.1']
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators

--- a/iiol/mybookwishlist/views.py
+++ b/iiol/mybookwishlist/views.py
@@ -1,9 +1,8 @@
-from django.shortcuts import render
-from rest_framework.views import APIView
+from django.contrib.auth.mixins import LoginRequiredMixin
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
+from rest_framework_simplejwt.authentication import JWTAuthentication
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import render
-from django.contrib.auth.mixins import LoginRequiredMixin
 from .models import MybookWishlist
 from .serializers import MybookWishlistSerializer, UserSerializer
 from rest_framework.response import Response  
@@ -18,11 +17,11 @@ from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
-class TokenLoginRequiredMixin(LoginRequiredMixin):
+class JWTLoginRequiredMixin(LoginRequiredMixin):
     def dispatch(self, request, *args, **kwargs):
         """If token was provided, ignore authenticated status."""
         http_auth = request.META.get("HTTP_AUTHORIZATION")
-        if http_auth and "Token" in http_auth:
+        if http_auth and "Bearer" in http_auth:
             pass
 
         elif not request.user.is_authenticated:
@@ -31,12 +30,12 @@ class TokenLoginRequiredMixin(LoginRequiredMixin):
         return super(LoginRequiredMixin, self).dispatch(
             request, *args, **kwargs)
 
-class MybookWishListViewSet(TokenLoginRequiredMixin, viewsets.ViewSet):
+class MybookWishListViewSet(JWTLoginRequiredMixin, viewsets.ViewSet):
     basename = 'mylist'
     login_url = f'{settings.FORCE_SCRIPT_NAME}/accounts/login'
     authentication_classes = [
         SessionAuthentication,
-        TokenAuthentication,
+        JWTAuthentication,
         ]
     permission_classes = [IsAuthenticated]
     filter_backends = [filters.SearchFilter]

--- a/iiol/requirements/common.txt
+++ b/iiol/requirements/common.txt
@@ -3,6 +3,7 @@ django-bootstrap5
 pillow
 easy-thumbnails
 djangorestframework
+djangorestframework-simplejwt~=5.3.0
 markdown
 django-filter 
 python-dotenv


### PR DESCRIPTION
# Throttle 사용
- 과오용방지를 위해 설정. 미인증 유저의 경우 100건/시간, 인증유저는 3건/초로 의도하지않은 과도한 요청으로 서버에 문제가 생기는 것을 방지함.

# JWT Token 인증 사용
- /accounts/token(Verify, refresh)를 통해 JWT 토큰 관리 가능.
- 현재 화면에서는 Session을 통해 로그인되고 있음.
- 추후 로그인 성공시 Return값으로 JWT 토큰값을 갱신/발급하는 로직 필요